### PR TITLE
fix: prevent Iterator to loop forever

### DIFF
--- a/pyzscaler/zia/locations.py
+++ b/pyzscaler/zia/locations.py
@@ -157,7 +157,7 @@ class LocationsAPI(APIEndpoint):
 
         """
         return list(
-            Iterator(self._api, f"locations/{location_id}/sublocations", **kwargs)
+            Iterator(self._api, f"locations/{location_id}/sublocations", max_pages=1, **kwargs)
         )
 
     def list_locations_lite(self, **kwargs):


### PR DESCRIPTION
It seems the Zscaler-API is behaving a bit odd for sublocations. It does not care about the page query-param.

A call to : `/locations/30920164/sublocations?page=10` will still produce the same set of sublocations as
`/locations/30920164/sublocations?page=1`

This causes the Iterator to go into an infinite loop when trying to list all sub locations of a parent location as it does not stop until it gets an empty list as response.

Either we do not use the Iterator for sublocations or, as I suggest we simply add `max_pages=1` to the call as it will only be one page anyway.