### PR TITLE
Add beta support to zpa

### DIFF
--- a/pyzscaler/zpa/lss.py
+++ b/pyzscaler/zpa/lss.py
@@ -21,7 +21,7 @@ class LSSConfigControllerAPI(APIEndpoint):
         super().__init__(api)
 
         self.v2_url = api.v2_url
-        self.v2_admin_url = "https://config.private.zscaler.com/mgmtconfig/v2/admin/lssConfig"
+        self.v2_admin_url = f"{api.base_url}/mgmtconfig/v2/admin/lssConfig"
 
     def _create_policy(self, conditions: list) -> list:
         """

--- a/pyzscaler/zpa/session.py
+++ b/pyzscaler/zpa/session.py
@@ -2,7 +2,7 @@ from restfly.endpoint import APIEndpoint
 
 
 class AuthenticatedSessionAPI(APIEndpoint):
-    def create_token(self, client_id: str, client_secret: str):
+    def create_token(self, client_id: str, client_secret: str, base_url: str):
         """
         Creates a ZPA authentication token.
 
@@ -24,4 +24,4 @@ class AuthenticatedSessionAPI(APIEndpoint):
         headers = {
             "Content-Type": "application/x-www-form-urlencoded",
         }
-        return self._post("https://config.private.zscaler.com/signin", headers=headers, data=payload).access_token
+        return self._post(f"{base_url}/signin", headers=headers, data=payload).access_token


### PR DESCRIPTION
Added support for the https://admin.zpabeta.net endpoint (or any other arbitrary endpoint that may exist in the future).  If this looks good I'll do the same for ZIA.

Sample:
```python
zpa = ZPA(
    base_url='https://config.zpabeta.net',
)
```
...or...
```bash
export ZPA_URL=config.zpabeta.net
```

If "https://" is missing it is added.
