### PR TITLE
docs: fix zpa.session example code

### DIFF
--- a/pyzscaler/zpa/session.py
+++ b/pyzscaler/zpa/session.py
@@ -20,7 +20,7 @@ class AuthenticatedSessionAPI(APIEndpoint):
             :obj:`dict`: The authenticated session information.
 
         Examples:
-            >>> zpa.session.create(client_id='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx==',
+            >>> zpa.session.create_token(client_id='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx==',
             ...    client_secret='yyyyyyyyyyyyyyyyyyyyyyyyyyyyyy')
 
         """


### PR DESCRIPTION
Here in the example it's using `zpa.session.create`, but the correct method is `zpa.session.create_token`.

ZIA (and not ZPA) has a `zpa.session.create` method, maybe that's where the typo comes from :)