### PR TITLE
feat: isolation policy/isolation profiles

### DIFF
--- a/pyzscaler/zpa/__init__.py
+++ b/pyzscaler/zpa/__init__.py
@@ -23,6 +23,7 @@ from pyzscaler.zpa.servers import AppServersAPI
 from pyzscaler.zpa.service_edges import ServiceEdgesAPI
 from pyzscaler.zpa.session import AuthenticatedSessionAPI
 from pyzscaler.zpa.trusted_networks import TrustedNetworksAPI
+from pyzscaler.zpa.isolation_profiles import IsolationProfilesAPI
 
 
 class ZPA(APISession):
@@ -249,3 +250,11 @@ class ZPA(APISession):
 
         """
         return TrustedNetworksAPI(self)
+
+    @property
+    def isolation_profiles(self):
+        """
+        The interface object for the :ref:`ZPA Isolation Profiles interface <zpa-isolation_profiles>`.
+
+        """
+        return IsolationProfilesAPI(self)

--- a/pyzscaler/zpa/isolation_profiles.py
+++ b/pyzscaler/zpa/isolation_profiles.py
@@ -1,0 +1,36 @@
+from box import BoxList
+from restfly import APISession
+from restfly.endpoint import APIEndpoint
+
+from pyzscaler.utils import Iterator
+
+
+class IsolationProfilesAPI(APIEndpoint):
+    def __init__(self, api: APISession):
+        super().__init__(api)
+
+        self._url = api._url
+
+    def list_profiles(self, **kwargs) -> BoxList:
+        """
+        Returns a list of all configured isolation profiles.
+
+        Keyword Args:
+            **max_items (int):
+                The maximum number of items to request before stopping iteration.
+            **max_pages (int):
+                The maximum number of pages to request before stopping iteration.
+            **pagesize (int):
+                Specifies the page size. The default size is 20, but the maximum size is 500.
+            **search (str, optional):
+                The search string used to match against features and fields.
+
+        Returns:
+            :obj:`BoxList`: A list of all configured isolation profiles.
+
+        Examples:
+            >>> for isolation_profile in zpa.isolation_profiles.list_profiles():
+            ...    pprint(isolation_profile)
+
+        """
+        return BoxList(Iterator(self._api, f"{self._url}/isolation/profiles", **kwargs))

--- a/tests/zpa/test_zpa_isolation_profiles.py
+++ b/tests/zpa/test_zpa_isolation_profiles.py
@@ -1,0 +1,33 @@
+import pytest
+import responses
+from box import BoxList
+
+from tests.conftest import stub_sleep
+
+
+# Don't need to test the data structure as we just have list and get
+# methods available. id will suffice until add/update endpoints are available.
+@pytest.fixture(name="isolation_profiles")
+def fixture_isolation_profiles():
+    return {"totalPages": 1, "list": [{"id": "1"}, {"id": "2"}]}
+
+
+@responses.activate
+@stub_sleep
+def test_list_isolation_profiles(zpa, isolation_profiles):
+    responses.add(
+        responses.GET,
+        url="https://config.private.zscaler.com/mgmtconfig/v1/admin/customers/1/isolation/profiles?page=1",
+        json=isolation_profiles,
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        url="https://config.private.zscaler.com/mgmtconfig/v1/admin/customers/1/isolation/profiles?page=2",
+        json=[],
+        status=200,
+    )
+    resp = zpa.isolation_profiles.list_profiles()
+    assert isinstance(resp, BoxList)
+    assert len(resp) == 2
+    assert resp[0].id == "1"


### PR DESCRIPTION
Hi @mitchos,

At the beginning let me thank you for your work done on this SDK.

We started using Isolation profiles/policies in prod on Zscaler tenant. That configuration is currently not available via this SDK. We want to push everything via YAML and APIs, but this was missing - that was our motivation to create this PR.

Added support for ZPA Isolation configuration via API (profiles and policies). Tests for created functions were also added. Docstring were updated in other methods to show, that they support new policy_type - isolation (reorder,update,delete). All added methods were tested directly with Zscaler API endpoints.
