### PR TITLE
Invalid escape sequences in docstrings

### DIFF
--- a/pyzscaler/zia/dlp.py
+++ b/pyzscaler/zia/dlp.py
@@ -6,7 +6,7 @@ from pyzscaler.utils import snake_to_camel
 
 class DLPAPI(APIEndpoint):
     def add_dict(self, name: str, match_type: str, **kwargs) -> Box:
-        """
+        r"""
         Add a new Patterns and Phrases DLP Dictionary to ZIA.
 
         Args:
@@ -112,7 +112,7 @@ class DLPAPI(APIEndpoint):
         return self._post("dlpDictionaries", json=payload)
 
     def update_dict(self, dict_id: str, **kwargs) -> Box:
-        """
+        r"""
         Updates the specified DLP Dictionary.
 
         Args:


### PR DESCRIPTION
## Summary

Fixes a couple of `SyntaxWarning` warnings raised by invalid escape sequences in doctsrings by converting them to raw docstrings.

![image](https://github.com/user-attachments/assets/30d917db-f2fc-4d88-9338-3b52a31c1c26)
